### PR TITLE
free from depending on underscore mixin _.isInt

### DIFF
--- a/cordova-geolocation.js
+++ b/cordova-geolocation.js
@@ -62,7 +62,8 @@ GeolocationFG.watch = function(onSuccess, timeout, options) {
   if (!_.isFunction(onSuccess)) {
     throw new Meteor.Error(500, 'GeolocationFG.watch onSuccess is not a function');
   }
-  if (!_.isInt(timeout)) {
+  //check if timeout is an integer
+  if ( !(parseInt(timeout, 10) == timeout) ) {
     timeout = 30000;
   }
   if (!_.isObject(options)) {


### PR DESCRIPTION
My app crashed with the following error:

```
Uncaught Error: TypeError: undefined is not a function (evaluating '_.isInt(timeout)')
```

I tried to mixin isInt into underscore, but that didn't work either (same error).
lib/underscore_mixins.coffee

```
_.mixin isInteger: (s) ->
  parseInt(s, 10) == s
```
